### PR TITLE
Fix mediawiki polling cron

### DIFF
--- a/integrations/mediawiki.js
+++ b/integrations/mediawiki.js
@@ -171,6 +171,6 @@ module.exports = async function(robot, kredits) {
       .then(() => updateTimestampForNextFetch());
   }
 
-  cron.schedule('* 7 * * *', processWikiChangesSinceLastRun);
+  cron.schedule('0 7 * * *', processWikiChangesSinceLastRun);
 
 };


### PR DESCRIPTION
Was doing every minute after 7am, instead of every day once at 7am.