### PR TITLE
Fix wrong Gitea issue IDs/URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = async function(robot) {
     kredits = await new Kredits(signer.provider, signer, {
       // TODO support local devchain custom address
       apm: 'open.aragonpm.eth',
+      // addresses: { Kernel: '0x93aa4531329e4bf3efcd1ec0b74adb6f66d9d10e' }
       ipfsConfig
     }).init();
   } catch(error) {

--- a/integrations/gitea.js
+++ b/integrations/gitea.js
@@ -85,7 +85,7 @@ module.exports = async function(robot, kredits) {
   async function handleGiteaIssueClosed(data) {
     const issue       = data.issue;
     const repoName    = data.repository.full_name;
-    const web_url     = `${data.repository.html_url}/issues/${issue.id}`;
+    const web_url     = `${data.repository.html_url}/issues/${issue.number}`;
     const description = `${repoName}: ${issue.title}`;
     const amount      = amountFromLabels(issue.labels);
     const assignees   = issue.assignees ? issue.assignees.map(a => a.login) : [];


### PR DESCRIPTION
Internal issue IDs are different from the public ones in Gitea. The one used in URLs etc. is called "number" instead of "id" in hook payloads.

fixes #33