### PR TITLE
Use new ethers.js NonceManager to handle transaction nonces 

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const util = require('util');
 const fetch = require('node-fetch');
 const ethers = require('ethers');
+const NonceManager = require('@ethersproject/experimental').NonceManager;
 const Kredits = require('kredits-contracts');
 
 const walletPath  = process.env.KREDITS_WALLET_PATH || './wallet.json';
@@ -43,7 +44,7 @@ module.exports = async function(robot) {
   } else {
     ethProvider = new ethers.getDefaultProvider('rinkeby');
   }
-  const signer = wallet.connect(ethProvider);
+  const signer = new NonceManager(wallet.connect(ethProvider));
 
   //
   // Kredits contracts setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,10 +421,13 @@
         "@ethersproject/strings": "^5.0.0"
       }
     },
-    "@types/node": {
-      "version": "10.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -466,13 +469,14 @@
       "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA=="
     },
     "asn1.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
-      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
       "requires": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "async": {
@@ -483,10 +487,24 @@
         "lodash": "^4.17.14"
       }
     },
+    "async-iterator-to-pull-stream": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.3.0.tgz",
+      "integrity": "sha512-NjyhAEz/sx32olqgKIk/2xbWEM6o8qef1yetIgb0U/R3oBgndP1kE/0CslowH3jvnA94BO4I6OXpOkTKH7Z1AA==",
+      "requires": {
+        "get-iterator": "^1.0.2",
+        "pull-stream-to-async-iterator": "^1.0.1"
+      }
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "babel-code-frame": {
       "version": "6.22.0",
@@ -690,9 +708,9 @@
       "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
     },
     "bignumber.js": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -711,17 +729,24 @@
       }
     },
     "bl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -729,9 +754,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -781,21 +806,41 @@
       }
     },
     "borc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.1.tgz",
-      "integrity": "sha512-vPLLC2/gS0QN4O3cnPh+8jLshkMMD4qIfs+B1TPGPh30WrtcfItaO6j4k9alsqu/hIgKi8dVdmMvTcbq4tIF7A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
       "requires": {
         "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
         "commander": "^2.15.0",
-        "ieee754": "^1.1.8",
-        "iso-url": "~0.4.4",
-        "json-text-sequence": "~0.1.0"
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         }
       }
     },
@@ -845,9 +890,9 @@
       }
     },
     "buffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-      "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -858,15 +903,15 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
-    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "callbackify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
+      "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
     },
     "chalk": {
       "version": "1.1.3",
@@ -881,14 +926,15 @@
       }
     },
     "cids": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.8.tgz",
-      "integrity": "sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
       "requires": {
+        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
         "multibase": "~0.6.0",
-        "multicodec": "~0.5.0",
-        "multihashes": "~0.4.14"
+        "multicodec": "^1.0.0",
+        "multihashes": "~0.4.15"
       }
     },
     "cipher-base": {
@@ -910,48 +956,23 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-      "from": "github:hugomrdias/concat-stream#feat/smaller",
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -1091,6 +1112,11 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
       "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
@@ -1114,11 +1140,6 @@
         "repeating": "^2.0.0"
       }
     },
-    "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
-    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -1135,14 +1156,17 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-      "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
         "hash.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "encodeurl": {
@@ -1150,18 +1174,10 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
     "err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1238,6 +1254,11 @@
         "@ethersproject/wordlists": "^5.0.0"
       }
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -1251,6 +1272,11 @@
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "express": {
       "version": "4.17.1",
@@ -1349,6 +1375,11 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1378,11 +1409,6 @@
         }
       }
     },
-    "flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1396,6 +1422,16 @@
         "for-in": "^1.0.1"
       }
     },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1406,15 +1442,25 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-value": {
       "version": "3.0.1",
@@ -1441,6 +1487,11 @@
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "grant": {
       "version": "4.6.1",
@@ -1482,12 +1533,43 @@
       }
     },
     "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "hash.js": {
@@ -1586,9 +1668,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
     },
     "ipaddr.js": {
       "version": "1.9.0",
@@ -1602,68 +1684,48 @@
       "requires": {
         "cids": "~0.7.0",
         "class-is": "^1.1.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
-          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
-          "requires": {
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "~0.5.1",
-            "multihashes": "~0.4.14"
-          }
-        }
       }
     },
     "ipfs-http-client": {
-      "version": "30.1.4",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.4.tgz",
-      "integrity": "sha512-ordvoPT3lAFL5qsvdYBeDGRP03gtbL6Jl+qJ9dztyhE7NJf2yhtnU3ZNqN1JMCcUK0qpGsDzX89t8dKQvI80Pw==",
+      "version": "41.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-41.0.1.tgz",
+      "integrity": "sha512-oyH0hXoB+jfz4NqM+SZSpk6c9wR+9uvUO+/0eQFT6B9Ludz4zR8T5MHo7bnQoVerj9Qlv0x0wO1ckSoekaSPpw==",
       "requires": {
-        "async": "^2.6.1",
-        "bignumber.js": "^8.0.2",
-        "bl": "^3.0.0",
+        "abort-controller": "^3.0.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
+        "bignumber.js": "^9.0.0",
+        "bl": "^4.0.0",
         "bs58": "^4.0.1",
-        "buffer": "^5.2.1",
-        "cids": "~0.5.5",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+        "buffer": "^5.4.2",
+        "callbackify": "^1.1.0",
+        "cids": "~0.7.1",
         "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^1.1.2",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.0",
-        "ipld-dag-cbor": "~0.13.1",
-        "ipld-dag-pb": "~0.15.3",
-        "is-ipfs": "~0.6.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "lru-cache": "^5.1.1",
+        "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
+        "form-data": "^3.0.0",
+        "ipfs-block": "~0.8.1",
+        "ipfs-utils": "^0.4.2",
+        "ipld-dag-cbor": "~0.15.0",
+        "ipld-dag-pb": "^0.18.1",
+        "ipld-raw": "^4.0.0",
+        "is-ipfs": "~0.6.1",
+        "it-all": "^1.0.1",
+        "it-glob": "0.0.7",
+        "it-tar": "^1.1.1",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
+        "ky": "^0.15.0",
+        "ky-universal": "^0.3.0",
+        "merge-options": "^2.0.0",
         "multiaddr": "^6.0.6",
+        "multiaddr-to-uri": "^5.0.0",
         "multibase": "~0.6.0",
-        "multicodec": "~0.5.0",
+        "multicodec": "^1.0.0",
         "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
+        "parse-duration": "^0.1.1",
+        "peer-id": "~0.12.3",
         "peer-info": "~0.15.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
+        "promise-nodeify": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -1674,28 +1736,35 @@
             "ms": "^2.1.1"
           }
         },
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
+        }
+      }
+    },
+    "ipfs-utils": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.4.2.tgz",
+      "integrity": "sha512-k/uNOniniqg7uCnHvmujis8ASNefn0url8GS7HaNLAhL3RV3dHBiibtQFp8JZ/zfN+80FrYJt7cPEzRbGbmJUA==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "err-code": "^2.0.0",
+        "fs-extra": "^8.1.0",
+        "is-buffer": "^2.0.3",
+        "is-electron": "^2.2.0",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^2.0.0",
+        "it-glob": "0.0.7",
+        "kind-of": "^6.0.2",
+        "pull-stream-to-async-iterator": "^1.0.2",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1703,9 +1772,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -1714,52 +1783,142 @@
           "requires": {
             "safe-buffer": "~5.2.0"
           }
-        },
-        "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-          "requires": {
-            "readable-stream": "2 || 3"
-          }
         }
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz",
-      "integrity": "sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
+      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
       "requires": {
-        "borc": "^2.1.0",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.5",
+        "borc": "^2.1.2",
+        "buffer": "^5.5.0",
+        "cids": "~0.8.0",
         "is-circular": "^1.0.2",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.1",
-        "traverse": "~0.6.6"
+        "multicodec": "^1.0.0",
+        "multihashing-async": "~0.8.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipld-dag-pb": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.3.tgz",
-      "integrity": "sha512-J1RJzSVCaOpxPmSzXbwVNsAZPHctjY4OjqG1dMIG86Z37CKvuy1QwCFkDhNccUTcQpF3sXfj5e0ZUyMM035vzg==",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
       "requires": {
-        "async": "^2.6.1",
-        "bs58": "^4.0.1",
-        "cids": "~0.5.4",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.0",
         "class-is": "^1.1.0",
-        "is-ipfs": "~0.6.0",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-traverse": "^1.0.3",
-        "stable": "~0.1.8"
+        "multicodec": "^1.0.1",
+        "multihashing-async": "~0.8.1",
+        "protons": "^1.0.2",
+        "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
+    },
+    "ipld-raw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
+      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
+      "requires": {
+        "cids": "~0.7.0",
+        "multicodec": "^1.0.0",
+        "multihashing-async": "~0.8.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-circular": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
       "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
+    },
+    "is-electron": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -1770,38 +1929,108 @@
       }
     },
     "is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
       "requires": {
-        "ip-regex": "^2.0.0"
+        "ip-regex": "^4.0.0"
       }
     },
     "is-ipfs": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.1.tgz",
-      "integrity": "sha512-WhqQylam6pODS2RyqT/u0PR5KWtBZNCgPjgargFOVQjzw/3+6d0midXenzU65klM4LH13IUiCC6ObhDUdXZ7Nw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
+      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
       "requires": {
         "bs58": "^4.0.1",
         "cids": "~0.7.0",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.0.4",
+        "mafmt": "^7.0.0",
+        "multiaddr": "^7.2.1",
         "multibase": "~0.6.0",
         "multihashes": "~0.4.13"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.1.tgz",
-          "integrity": "sha512-qEM4j2GKE/BiT6WdUi6cfW8dairhSLTUE8tIdxJG6SvY33Mp/UPjw+xcO0n1zsllgo72BupzKF/44v+Bg8YPPg==",
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "~0.5.1",
-            "multihashes": "~0.4.14"
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "cids": {
+              "version": "0.8.3",
+              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+              "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "class-is": "^1.1.0",
+                "multibase": "^1.0.0",
+                "multicodec": "^1.0.1",
+                "multihashes": "^1.0.1"
+              },
+              "dependencies": {
+                "multibase": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+                  "requires": {
+                    "base-x": "^3.0.8",
+                    "buffer": "^5.5.0"
+                  }
+                }
+              }
+            },
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              },
+              "dependencies": {
+                "multibase": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+                  "requires": {
+                    "base-x": "^3.0.8",
+                    "buffer": "^5.5.0"
+                  }
+                }
+              }
+            }
           }
         }
       }
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -1822,34 +2051,33 @@
       "integrity": "sha1-o7w9HG0wVRUcRr3m85nv7SFEDKk="
     },
     "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "iso-random-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.0.tgz",
-      "integrity": "sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ=="
-    },
-    "iso-stream-http": {
+    "iso-constants": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
-      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
+      "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
+    },
+    "iso-random-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
+      "integrity": "sha512-YEt/7xOwTdu4KXIgtdgGFkiLUsBaddbnkmHyaFdjJYIcD7V4gpQHPvYC5tyh3kA0PQ01y9lWm1ruVdf8Mqzovg==",
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
+        "buffer": "^5.4.3",
+        "readable-stream": "^3.4.0"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1857,9 +2085,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -1872,9 +2100,9 @@
       }
     },
     "iso-url": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.6.tgz",
-      "integrity": "sha512-YQO7+aIe6l1aSJUKOx+Vrv08DlhZeLFIVfehG2L29KLSEb9RszqPXilxJRVpp57px36BddKR5ZsebacO5qG0tg=="
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
     "isobject": {
       "version": "3.0.1",
@@ -1885,6 +2113,110 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "it-all": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
+      "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg=="
+    },
+    "it-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.0.tgz",
+      "integrity": "sha512-mLhiCB3tW4NTYTg7bMlyYX2c782KsAacthHMR3y5kjJn9JhNFb02NcH70KZuNrSXFSTq8k6m8MiYaQWRjrDxAA==",
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
+    "it-glob": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
+      "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-reader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
+      "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
+    "it-tar": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
+      "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
+      "requires": {
+        "bl": "^4.0.0",
+        "buffer": "^5.4.3",
+        "iso-constants": "^0.1.2",
+        "it-concat": "^1.0.0",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "js-sha3": {
       "version": "0.5.7",
@@ -1901,11 +2233,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "json-text-sequence": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
@@ -1919,15 +2246,13 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
-    "just-kebab-case": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
-      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
-    },
-    "just-map-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.1.0.tgz",
-      "integrity": "sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g=="
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "keypair": {
       "version": "1.0.1",
@@ -1948,38 +2273,20 @@
       }
     },
     "kredits-contracts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/kredits-contracts/-/kredits-contracts-5.4.0.tgz",
-      "integrity": "sha512-Oz5c+wbuDhZ0uYKRWPxSpsNiUXdrZlJ6Vp/+IMMSjD/TmlHGwP2Pnmloyq4Xjim0JbA/bJSjyBdy62dCrqCLrw==",
+      "version": "github:67P/kredits-contracts#c2dcedfe58415e4edac344ed1dff4e76e125118f",
+      "from": "github:67P/kredits-contracts#ethers5",
       "requires": {
-        "ethers": "^4.0.29",
-        "ipfs-http-client": "^30.1.3",
-        "kosmos-schemas": "^2.1.0",
+        "ethers": "^5.0.2",
+        "ipfs-http-client": "^41.0.1",
+        "kosmos-schemas": "^2.2.1",
         "node-fetch": "^2.6.0",
         "tv4": "^1.3.0"
       },
       "dependencies": {
-        "ethers": {
-          "version": "4.0.36",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.36.tgz",
-          "integrity": "sha512-rWdchEhUyXx01GiwexH6Sha97CQ9tJdQwe6FtYKxShC7VEZV41nuKt+lzCQ4OqvQwZK5PcAKaAZv2GDsCH33SA==",
-          "requires": {
-            "@types/node": "^10.3.2",
-            "aes-js": "3.0.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
         "kosmos-schemas": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/kosmos-schemas/-/kosmos-schemas-2.1.0.tgz",
-          "integrity": "sha512-RT90o0ujAKoCUpcYHi5ijDxg9F9enY5aOIZXujidjkCQ/hgjJ2tyNi+x8rszutsAP/mx64yj307oWJWhNZTyTg==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/kosmos-schemas/-/kosmos-schemas-2.2.1.tgz",
+          "integrity": "sha512-bZRbwLmJVeaaLqIyJsHbUf7wCjgHP2IhKXH12fD5+1tcw6/bdtZF4nZ41SoVCmdnZnSXh6Fv8nIRT0HksSlj8w==",
           "requires": {
             "brfs-babel": "^1.0.0"
           }
@@ -1991,10 +2298,31 @@
         }
       }
     },
+    "ky": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.15.0.tgz",
+      "integrity": "sha512-6IlJRPFHq4ZKRRa9lyh6YqHqlmddAkfyXI9CYvZpLQtg7fQvwncPHyHrmtXAHKCqHOilINPMT88eW6FTA3HwkA=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
     "libp2p-crypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-      "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.3.tgz",
+      "integrity": "sha512-ro7/5Tu+f8p2+qDS1JrROnO++nNaAaBFs+VVXVHLuTMnbnMASu1eUtSlWPk1uOwikAlBFTvfqe5J1bK6Bpq6Pg==",
       "requires": {
         "asmcrypto.js": "^2.3.2",
         "asn1.js": "^5.0.1",
@@ -2006,12 +2334,31 @@
         "keypair": "^1.0.1",
         "libp2p-crypto-secp256k1": "~0.3.0",
         "multihashing-async": "~0.5.1",
-        "node-forge": "~0.7.6",
+        "node-forge": "~0.9.1",
         "pem-jwk": "^2.0.0",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.9.10"
+        "ursa-optional": "~0.10.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multihashing-async": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
+          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        }
       }
     },
     "libp2p-crypto-secp256k1": {
@@ -2045,9 +2392,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -2055,11 +2402,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -2069,20 +2411,88 @@
         "js-tokens": "^3.0.0"
       }
     },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "requires": {
-        "yallist": "^3.0.2"
-      }
-    },
     "mafmt": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.8.tgz",
-      "integrity": "sha512-6oRO2fwNiqXXiby8Anq9ULLQpcrZUsfR3Bs+Yn1DWd/Zd65xGS9fobKzzSsnM9nqUdUA3IggG0b1R3WamVsatA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
+      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
       "requires": {
-        "multiaddr": "^6.1.0"
+        "multiaddr": "^7.3.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        }
       }
     },
     "md5.js": {
@@ -2096,9 +2506,9 @@
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -2111,6 +2521,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
+      "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -2153,11 +2571,6 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -2179,9 +2592,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiaddr": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-      "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
@@ -2189,20 +2602,120 @@
         "ip": "^1.1.5",
         "is-ip": "^2.0.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+        },
+        "is-ip": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
+          "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+          "requires": {
+            "ip-regex": "^2.0.0"
+          }
+        }
       }
     },
-    "multibase": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
-      "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+    "multiaddr-to-uri": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
+      "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
       "requires": {
-        "base-x": "3.0.4"
+        "multiaddr": "^7.2.1"
       },
       "dependencies": {
         "base-x": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
-          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "multibase": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -2210,38 +2723,87 @@
       }
     },
     "multicodec": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.5.tgz",
-      "integrity": "sha512-1kOifvwAqp9IdiiTKmpK2tS+LY6GHZdKpk3S2EvW4T32vlwDyA3hJoZtGauzqdedUPVNGChnTksEotVOCVlC+Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.3.tgz",
+      "integrity": "sha512-8G4JKbHWSe/39Xx2uiI+/b/S6mGgimzwEN4TOCokFUIfofg1T8eHny88ht9eWImD2dng+EEQRsApXxA5ubhU4g==",
       "requires": {
+        "buffer": "^5.6.0",
         "varint": "^5.0.0"
       }
     },
     "multihashes": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
-      "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
       "requires": {
-        "bs58": "^4.0.1",
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
       }
     },
     "multihashing-async": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-      "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
       "requires": {
         "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
+        "buffer": "^5.4.3",
+        "err-code": "^2.0.0",
+        "js-sha3": "^0.8.0",
+        "multihashes": "^1.0.1",
+        "murmurhash3js-revisited": "^3.0.0"
       },
       "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
@@ -2250,40 +2812,25 @@
       "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
       "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
     },
+    "murmurhash3js-revisited": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+      "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "ncp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
-    },
-    "ndjson": {
-      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-          "requires": {
-            "readable-stream": "2 || 3"
-          }
-        }
-      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -2305,9 +2852,9 @@
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
     "nodeify": {
       "version": "1.0.1",
@@ -2385,6 +2932,25 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "parse-duration": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.3.tgz",
+      "integrity": "sha512-hMOZHfUmjxO5hMKn7Eft+ckP2M4nV4yzauLXiw3PndpkASnx5r8pDAMcOAiqxoemqWjMWmz4fOHQM6n6WwETXw=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2401,9 +2967,9 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "peer-id": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.4.tgz",
-      "integrity": "sha512-AIAwL/6CmVc/VKbUhpA1rY3A/VJ3Z9ELvtvDQfl5cIi0A74L7lvsJ6LxQn5JSJVHM5Us2Ng9zMO523dO3FFnnw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
+      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
       "requires": {
         "async": "^2.6.3",
         "class-is": "^1.1.0",
@@ -2420,6 +2986,16 @@
         "multiaddr": "^6.0.3",
         "peer-id": "~0.12.2",
         "unique-by": "^1.0.0"
+      },
+      "dependencies": {
+        "mafmt": {
+          "version": "6.0.10",
+          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+          "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+          "requires": {
+            "multiaddr": "^6.1.0"
+          }
+        }
       }
     },
     "pem-jwk": {
@@ -2453,10 +3029,10 @@
         "is-promise": "~1"
       }
     },
-    "promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
+    "promise-nodeify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
+      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
     },
     "prompt": {
       "version": "1.0.0",
@@ -2472,17 +3048,17 @@
       }
     },
     "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
+      "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "protons": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
-      "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
       "requires": {
+        "buffer": "^5.5.0",
         "protocol-buffers-schema": "^3.3.1",
-        "safe-buffer": "^5.1.1",
         "signed-varint": "^2.0.1",
         "varint": "^5.0.0"
       }
@@ -2496,61 +3072,17 @@
         "ipaddr.js": "1.9.0"
       }
     },
-    "pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
     "pull-stream": {
       "version": "3.6.14",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
       "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
     },
-    "pull-to-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
-      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
+    "pull-stream-to-async-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-stream-to-async-iterator/-/pull-stream-to-async-iterator-1.0.2.tgz",
+      "integrity": "sha512-c3KRs2EneuxP7b6pG9fvQTIjatf33RbIErhbQ75s5r2MI6E8R74NZC1nJgXc8kcmqiQxmr+TWY+WwK2mWaUnlA==",
       "requires": {
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
-    "pull-traverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "pull-stream": "^3.6.9"
       }
     },
     "qs": {
@@ -2690,44 +3222,25 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "scrypt-js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-    },
     "secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
       "requires": {
         "bindings": "^1.5.0",
         "bip66": "^1.1.5",
         "bn.js": "^4.11.8",
         "create-hash": "^1.2.0",
         "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
+        "elliptic": "^6.5.2",
         "nan": "^2.14.0",
         "safe-buffer": "^5.1.2"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-          "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
-        },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -2791,11 +3304,6 @@
       "requires": {
         "is-plain-object": "^2.0.4"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -2863,39 +3371,6 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-6.1.0.tgz",
       "integrity": "sha512-9UBdnmnvx2NLLd4bMs7CEKK+wSzbujVv3ONyorkP1o8M3pVJQtXDO1cN19xD1JJs6ltOrtPrkUND0HzLSinUcA=="
     },
-    "split2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-      "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
-      "requires": {
-        "readable-stream": "^3.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -2910,15 +3385,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-      "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
-      }
     },
     "string_decoder": {
       "version": "1.0.3",
@@ -2941,43 +3407,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
-    "tar-stream": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
-      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
-      "requires": {
-        "bl": "^3.0.0",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        }
-      }
-    },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -2997,11 +3426,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -3013,9 +3437,9 @@
       "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
     },
     "tweetnacl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -3053,18 +3477,23 @@
       "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
       "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "ursa-optional": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
-      "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
+      "integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
       "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.11.1"
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
       }
     },
     "util-deprecate": {
@@ -3169,20 +3598,10 @@
         "cookiejar": "^2.1.1"
       }
     },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,423 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ensdomains/address-encoder": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@ensdomains/address-encoder/-/address-encoder-0.1.7.tgz",
+      "integrity": "sha512-p43NCgeyF3Q5ZEhEa24SN/UYUTKZIvFHwQ3xT8xqv4/iBbf7+efOP8Pl6kHbu6HI6pdWhTMvHOUR4UEDu4MN1g==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "crypto-addr-codec": "^0.1.7"
+      }
+    },
+    "@ethersproject/abi": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.1.tgz",
+      "integrity": "sha512-9fqSa3jEYV4nN8tijW+jz4UnT/Ma9/b8y4+nHlsvuWqr32E2kYsT9SCIVpk/51iM6NOud7xsA6UxCox9zBeHKg==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.1.tgz",
+      "integrity": "sha512-/KOw65ayviYPtKLqFE1qozeIJJlfI1wE/tNA+iKUPUai6bU6vg2tbfLFGarRTCQe3HoWV1t7xSsD/z9T9xg74g==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/web": "^5.0.0"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.1.tgz",
+      "integrity": "sha512-Rp8DP+cLcSNFkd1YhwPSBcgEWLRipNakitwIwHngAmhbo4zdiWgALD/OLqdQ7SKF75CufF1W4BCuXcQgiWaRow==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
+      "integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.1.tgz",
+      "integrity": "sha512-WZDa+TYl6BQfUm9EQIDDfJFL0GiuYXNZPIWoiZx3uds7P1XMsvcW3k71AyjYUxIkU5AKW7awwPbzCbBeP1uXsA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0"
+      }
+    },
+    "@ethersproject/basex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.1.tgz",
+      "integrity": "sha512-ssL2+p/A5bZgkZkiWy0iQDVz2mVJxZfzpf7dpw8t0sKF9VpoM3ZiMthRapH/QBhd4Rr6TNbr619pFLAGmMi9Ug==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.1.tgz",
+      "integrity": "sha512-srGDO7ksT0avdDw5pBtj6F81psv5xiJMInwSSatfIKplitubFb6yVwoHGObGRd0Pp3TvrkIDfJkuskoSMj4OHQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
+      "integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
+      "integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0"
+      }
+    },
+    "@ethersproject/contracts": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.1.tgz",
+      "integrity": "sha512-1uPajmkvw3Oy/dxs5TKUsGaXzQ3s5qiXKSVpw9ZrhGG6fMRO3gNyUA+uSWk9IXK0ulj5P95F7vW8HmYOkzep/Q==",
+      "requires": {
+        "@ethersproject/abi": "^5.0.0",
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0"
+      }
+    },
+    "@ethersproject/experimental": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/experimental/-/experimental-5.0.0.tgz",
+      "integrity": "sha512-AEjVi6uvV4LcHbIozUyM7i6UNj1pqqWV4PhJiVfpeYLVc7FpiIlOOQUGJUHyXLuwjqyBO6vrQrtP3u2x2mKPFQ==",
+      "requires": {
+        "@ensdomains/address-encoder": "^0.1.2",
+        "@ethersproject/web": "^5.0.0",
+        "ethers": "^5.0.0",
+        "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        }
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
+      "integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.1.tgz",
+      "integrity": "sha512-L2OZP4SKKxNtHUdwfK8cND09kHRH62ncxXW33WAJU9shKo8Sbz31HVqSdov84bMAGm8QfEKZbfbAJV/7DM6DjQ==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/basex": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.1.tgz",
+      "integrity": "sha512-QjqQCh1a0a6wRVHdnqVccCLWX0vAgxnvGZeGqpOk2NbyNE8HTzV7GpOE+4LU+iCc8oonfy1gYd4hpsf+iEUWGg==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1",
+        "uuid": "2.0.1"
+      },
+      "dependencies": {
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        }
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
+      "integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "js-sha3": "0.5.7"
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
+      "integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g=="
+    },
+    "@ethersproject/networks": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.1.tgz",
+      "integrity": "sha512-Pe34JCTC6Apm/DkK3z97xotvEyu9YHKIFlDIu5hGV6yFDb4/sUfY2SHKYSGdUrV0418ZZVrwYDveJtBFMmYu2Q==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.1.tgz",
+      "integrity": "sha512-4wc8Aov0iJmiomu6Dv1JNGOlhm3L7omITjLmChz/vgeDnW4Unv4J/nGybCeWKgY4hnjyQMVXkdkQ15BCRbkaYg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0"
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
+      "integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.2.tgz",
+      "integrity": "sha512-28ABJmHB9ii/73F3P9CXLBvlRkitiOGHCrUZqjQ6FELuAtKEROqA/yDklT9o/r/BpGcGTeeWpWfvdfgDHjshiw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/web": "^5.0.0",
+        "ws": "7.2.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.1.tgz",
+      "integrity": "sha512-nYzNhcp5Th4dCocV3yceZmh80bRmSQxqNRgND7Y/YgEgYJSSnknScpfRHACG//kgbsY8zui8ajXJeEnzS7yFbQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
+      "integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/sha2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.1.tgz",
+      "integrity": "sha512-5wNdULNDMJKwyzqrTH66e2TZPZTSqqluS7RNtuuuQSTP+yIALoID7ewLjDoj31g4kZyq/pqQbackKJLOXejTKw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "hash.js": "1.1.3"
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.1.tgz",
+      "integrity": "sha512-Z3yMPFFf4KkWltndDNi/tpese7qZh6ZWKbGu3DHd8xOX0PJqbScdAs6gCfFeMatO06qyX307Y52soc/Ayf8ZSg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "elliptic": "6.5.2"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+          "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.1.tgz",
+      "integrity": "sha512-3L+xI1LaJmd2zBJxnK9Y4cd1vb2aJLFvL6fxvjWpzcMiFiZ4dbPwj3kharv5f5mAlbGwAs6NiPJaFWvbOpm96Q==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
+      "integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
+      "integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
+      "requires": {
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.1.tgz",
+      "integrity": "sha512-7J7Jmm4hMZ+yFiqEd7D5oeVK/V74GDwQlT0Om1yxXLYX6UPcV5ChHkUz/xpHPT9JXQlQ+2D69HBf1dzvdflrmQ==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0"
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.1.tgz",
+      "integrity": "sha512-1/QPpFngJtUGtdVOLSoIN3vf+zEWyEVxQ0lhRCwGkiBqL2SoVoDHB7/nCfcv7wwlZkdnegFfo/8DxeyYjTZN7w==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/json-wallets": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.1.tgz",
+      "integrity": "sha512-lWPg8BR6KoyiIKYRIM6j+XO9bT9vGM1JnxFj2HmhIvOrOjba7ZRd8ANBOsDVGfw5igLUdfqAUOf9WpSsH//TzA==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.1.tgz",
+      "integrity": "sha512-R7boLmpewucz5v4jD7cWwI0BGHR/DstiZtjdhUOft6XdMqM1OGb1UTL0GBQeS4vDXzCLuJEHddjJ69beGVN/4Q==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0"
+      }
+    },
     "@types/node": {
       "version": "10.14.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
@@ -261,6 +678,16 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
     },
     "bignumber.js": {
       "version": "8.1.1",
@@ -617,6 +1044,35 @@
         "sha.js": "^2.4.8"
       }
     },
+    "crypto-addr-codec": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
+      "integrity": "sha512-X4hzfBzNhy4mAc3UpiXEC/L0jo5E8wAa9unsnA8nNXYzXjCcGk83hfC5avJWCSGT8V91xMnAS9AKMHmjw5+XCg==",
+      "requires": {
+        "base-x": "^3.0.8",
+        "big-integer": "1.6.36",
+        "blakejs": "^1.1.0",
+        "bs58": "^4.0.1",
+        "ripemd160-min": "0.0.6",
+        "safe-buffer": "^5.2.0",
+        "sha3": "^2.1.1"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -747,38 +1203,39 @@
       "integrity": "sha512-DqtdXNHGi/QtOjEovNOegVVQTd8/NnH9rP27R5SU3j2LKECZbcLGIZ3Z9Ln1SDaeUC5YJGJFYQCUUjfIi7NNyQ=="
     },
     "ethers": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-      "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.2.tgz",
+      "integrity": "sha512-hAWTPQXvjFlrtnPLCnOOJJuqiqmJv820egPHpOwcWTIQxXRrcfZyse2692eaqsXMeYLNM2CRfYgEomBiBGvgjw==",
       "requires": {
-        "@types/node": "^10.3.2",
-        "aes-js": "3.0.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.3.3",
-        "hash.js": "1.1.3",
-        "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.4",
-        "setimmediate": "1.0.4",
-        "uuid": "2.0.1",
-        "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "elliptic": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        }
+        "@ethersproject/abi": "^5.0.0",
+        "@ethersproject/abstract-provider": "^5.0.0",
+        "@ethersproject/abstract-signer": "^5.0.0",
+        "@ethersproject/address": "^5.0.0",
+        "@ethersproject/base64": "^5.0.0",
+        "@ethersproject/bignumber": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.0",
+        "@ethersproject/constants": "^5.0.0",
+        "@ethersproject/contracts": "^5.0.0",
+        "@ethersproject/hash": "^5.0.0",
+        "@ethersproject/hdnode": "^5.0.0",
+        "@ethersproject/json-wallets": "^5.0.0",
+        "@ethersproject/keccak256": "^5.0.0",
+        "@ethersproject/logger": "^5.0.0",
+        "@ethersproject/networks": "^5.0.0",
+        "@ethersproject/pbkdf2": "^5.0.0",
+        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/providers": "^5.0.0",
+        "@ethersproject/random": "^5.0.0",
+        "@ethersproject/rlp": "^5.0.0",
+        "@ethersproject/sha2": "^5.0.0",
+        "@ethersproject/signing-key": "^5.0.0",
+        "@ethersproject/solidity": "^5.0.0",
+        "@ethersproject/strings": "^5.0.0",
+        "@ethersproject/transactions": "^5.0.0",
+        "@ethersproject/units": "^5.0.0",
+        "@ethersproject/wallet": "^5.0.0",
+        "@ethersproject/web": "^5.0.0",
+        "@ethersproject/wordlists": "^5.0.0"
       }
     },
     "events": {
@@ -2201,6 +2658,11 @@
         "inherits": "^2.0.1"
       }
     },
+    "ripemd160-min": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+      "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A=="
+    },
     "rsa-pem-to-jwk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
@@ -2347,6 +2809,25 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "sha3": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.2.tgz",
+      "integrity": "sha512-agYUtkzMsdFTQkM3ECyt6YW0552fyEb0tYZkl7olurS1Vg2Ms5+2SdF4VFPC1jnwtiXMb8b0fSyuAGZh+q2mAw==",
+      "requires": {
+        "buffer": "5.5.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "signed-varint": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grant-express": "^4.6.1",
     "group-array": "^1.0.0",
     "kosmos-schemas": "^1.1.2",
-    "kredits-contracts": "github:67P/kredits-contracts#ethers5",
+    "kredits-contracts": "^6.0.0",
     "node-cron": "^2.0.3",
     "node-fetch": "^2.3.0",
     "prompt": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grant-express": "^4.6.1",
     "group-array": "^1.0.0",
     "kosmos-schemas": "^1.1.2",
-    "kredits-contracts": "^5.4.0",
+    "kredits-contracts": "github:67P/kredits-contracts#ethers5",
     "node-cron": "^2.0.3",
     "node-fetch": "^2.3.0",
     "prompt": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "eth-provider": "^0.2.2",
-    "ethers": "^4.0.27",
+    "ethers": "^5.0.2",
+    "@ethersproject/experimental": "5.0.0",
     "express": "^4.17.1",
     "express-session": "^1.16.2",
     "grant-express": "^4.6.1",


### PR DESCRIPTION
So far we have failed to globally handle the transaction nonces.
The new ethers.js v5 comes with a NonceManager that helps us handling transaction nonces and automatically increases the nonce for each transaction.

We should first release: https://github.com/67P/kredits-contracts/pull/200

TODO:
- [x] test
- [x] release kredits-contracts and use released kredits-contracts version