### PR TITLE
Only create small automatic contributions for wiki edits

### DIFF
--- a/integrations/mediawiki.js
+++ b/integrations/mediawiki.js
@@ -126,6 +126,7 @@ module.exports = async function(robot, kredits) {
     return [...new Set(changes.map(c => `"${c.title}"`))].join(', ');
   }
 
+  // Currently not used
   function calculateAmountForChanges(details) {
     let amount;
 
@@ -144,9 +145,7 @@ module.exports = async function(robot, kredits) {
     const dateNow = new Date();
     const dateYesterday = dateNow.setDate(dateNow.getDate() - 1);
     const date = (new Date(dateYesterday)).toISOString().split('T')[0];
-
-    const details = analyzeUserChanges(user, changes);
-    const amount = calculateAmountForChanges(details);
+    const amount = 500;
 
     let desc = `Added ${details.charsAdded} characters of text.`;
     if (details.pagesChanged.length > 0) {


### PR DESCRIPTION
We decided that it's too difficult for a machine to gauge the meaning and value of wiki edits by line numbers, so automatic kredits are now always a small contributions. Until we have new tools for larger wiki contributions (e.g. mediawiki tags), we can create manual contributions for those.